### PR TITLE
Fix README NFO encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,189 +2,189 @@
 
 
 ```
-                        ÜÛÛÛÛ    ÜÜÛÛÛÛÛÛÛÛÛÜÜ      ÜÛÛÛÛ   ÜÛÛÛÛ
-                        ÜÛÛÛÛÛÛ  ÜÛÛÛÛÛÛÛÛÛÛÛÛÛÛÛÜ  ÜÛÛÛÛÛÛ ÜÛÛÛÛÛÛ
-                        ßßßÛÛÛÛ ÜÛÛÛÛßß     ßßÛÛÛÛÜ ßßßÛÛÛÛ ßßßÛÛÛÛ
-                 ÜÜÛ       ÛÛÛÛ ÛÛÛÛ           ÛÛÛÛ    ÛÛÛÛ    ÛÛÛÛ
-             ÜÜÛÛÛÛÛÜÛÛÛÜÜÜÜ ßÛ ÛÛÛÛ           ÛÛÛÛ    ÛÛßß    ÛÛÛÛ
-               ßÛÛÛß ßßÛÛÛÛÛÛÜ  ßßßß           ßßßß    ß Üß    Ûß Ü
-                ÛÛÛ    ÜÛÛÛÛÛß ßßßÛÛÛÛ    ÜÛÛÛÛÛÛÛÛÛÜ  ÜÛÛÛÜ   ÜÜÛÛÜßÛÛÜÜ
-                ÛÛÛ  ÜÛÛßßßß Üß ÜÛÛßÛÛÛ   ßÛß   ÜÛÛß ÜÛß ßÛÛÛÜ  ÛÛÛ   ßÛÛÛÜ
-                ÛÛÛÜÛÛÜ    ÛÛß ÛÛÛ Ü ÛÛÛ ßÜÜ  ÜÛÛß ÜÛÛÜ ßÜ ßÛÛÛÜÛÛÛ  ÜÛÛßß
-                ÛÛÛßÛÛÛÛÜ  ÛÛ ÛÛÛß    ÛÛÛ ß ÜÛÛß   ÜÛÛÛÛÜ ß ÜÛß ÛÛÛßÛÛÜ
-                ÛÛÛ  ßÛÛÛÛÜ  ÜÛÛÛ ÜÜÛßßÛÛÛÜÛÛÛÜÜÜÜÛÛÛ ßÛÛÛÜÛß   ÛÛÛ  ßÛÛÜ
-               ÜÛÛÛÜ   ßÛÛÛÛÜßÛÛßßß   ßßßßÛÛÛßßßßßßß    ßÛß    ßßßßß   ßÛÛÜ
-              ßßßßßßß    ßÛÛÛÛÛÜÜ           ßßÜ ÛÛÛ     ß Ü    ÛÛÛÛ      ßßÛÛÜÜ  Ü
-                           ßßÛÛÛÛÛÛÛÜÜÜ   ÜÜß  ÜÛÛÛ    ÛÛÛÛ    ÛÛÛÛ           ßßß
-                           ÛÜÜÜ ßßßßÛÛÛÛÛßß    ÛÛÛÛ    ÛÛÛÛ    ÛÛÛÛ
-                           ÛÛÛÛ                ÛÛÛÛ    ÛÛÛÛ    ÛÛÛÛ
-                           ÛÛÛÛ                ÛÛÛÛ    ÛÛÛÛ    ÛÛÛÛ
-                                       ASCiiúJED<ACiD>
+                        ▄████    ▄▄█████████▄▄      ▄████   ▄████
+                        ▄██████  ▄███████████████▄  ▄██████ ▄██████
+                        ▀▀▀████ ▄████▀▀     ▀▀████▄ ▀▀▀████ ▀▀▀████
+                 ▄▄█       ████ ████           ████    ████    ████
+             ▄▄█████▄███▄▄▄▄ ▀█ ████           ████    ██▀▀    ████
+               ▀███▀ ▀▀██████▄  ▀▀▀▀           ▀▀▀▀    ▀ ▄▀    █▀ ▄
+                ███    ▄█████▀ ▀▀▀████    ▄█████████▄  ▄███▄   ▄▄██▄▀██▄▄
+                ███  ▄██▀▀▀▀ ▄▀ ▄██▀███   ▀█▀   ▄██▀ ▄█▀ ▀███▄  ███   ▀███▄
+                ███▄██▄    ██▀ ███ ▄ ███ ▀▄▄  ▄██▀ ▄██▄ ▀▄ ▀███▄███  ▄██▀▀
+                ███▀████▄  ██ ███▀    ███ ▀ ▄██▀   ▄████▄ ▀ ▄█▀ ███▀██▄
+                ███  ▀████▄  ▄███ ▄▄█▀▀███▄███▄▄▄▄███ ▀███▄█▀   ███  ▀██▄
+               ▄███▄   ▀████▄▀██▀▀▀   ▀▀▀▀███▀▀▀▀▀▀▀    ▀█▀    ▀▀▀▀▀   ▀██▄
+              ▀▀▀▀▀▀▀    ▀█████▄▄           ▀▀▄ ███     ▀ ▄    ████      ▀▀██▄▄  ▄
+                           ▀▀███████▄▄▄   ▄▄▀  ▄███    ████    ████           ▀▀▀
+                           █▄▄▄ ▀▀▀▀█████▀▀    ████    ████    ████
+                           ████                ████    ████    ████
+                           ████                ████    ████    ████
+                                       ASCii·JED<ACiD>
        
-        ÖÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄ·
-        º The Billion Dollar Torrent:                                                º
-        º All the NFT's on the Ethereum & Solana blockchains.                        º
-        ÓÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄ½
+        ╓────────────────────────────────────────────────────────────────────────────╖
+        ║ The Billion Dollar Torrent:                                                ║
+        ║ All the NFT's on the Ethereum & Solana blockchains.                        ║
+        ╙────────────────────────────────────────────────────────────────────────────╜
        
-        ÖÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄ·
-        º                                                                            º
-        º  úúú Written By :  http://twitter.com/geoffreyhuntley                      º
-        º                                                                            º
-        ÇÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄ¶
-        º                                                                            º
-        º  úúú Release Notes : Did you know that a NFT is just a hyperlink [1] to an º
-        º                    image thats usually hosted on Google Drive or another   º
-        º                    web2.0 webhost?                                         º   
-        º                                                                            º
-        º                    People are dropping millions on instructions on how to  º
-        º                    download images. That's why you can right click save-as º
-        º                    because they are standard images. The image is not      º
-        º                    stored in the blockchain contract.                      º
-        º                                                                            º
-        º                    As web2.0 webhosts are known to go offline (404 errors) º
-        º                    this handy torrent contains all of the NFT's so that    º
-        º                    future generations can study this generations tulip     º
-        º                    mania and collectively go...                            º
-        º                                                                            º
-        º                                                                            º
-        º                    "WTF? We destroyed our planet for THIS?!"               º
-        º                                                                            º
-        º                                           --- Geoffrey Huntley             º
-        º                                                                            º
-        º [1] https://arweave.news/nft-404/                                          º
-        º                                                                            º
-        ÇÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄ¶
-        º                                                                            º
-        º  úúú Group News :  RAZOR 1911 has experienced a few changes over the last  º
-        º                    weeks so, but rest assured, the rumours of our          º
-        º                    demise have been GREATLY exaggerated...                 º
-        º                                                                            º
-        º                    Please welcome back to RAZOR BLADE to the RAZOR 1911    º
-        º                    Leader board!                                           º
-        º                                                                            º
-        º                    Please welcome back to THE RENEGADE CHEMIST to the      º
-        º                    RAZOR 1911 member list!                                 º
-        º                                                                            º
-        º                    Please welcome DARK OVERLORD to the RAZOR 1911          º
-        º                    cracking team!                                          º
-        º                                                                            º
-        º                    Please welcome KEANU to the RAZOR 1911 team!            º
-        º                                                                            º
-        º                    Please also give welcome to RAZOR's newest additions    º
-        º                    to the kick-ass spread team:  The Calibre &             º
-        º                    Black Mantle                                            º
-        º                                                                            º
-        º                    Please welcome RAZOR'S newest affiliate:                º
-        º                    THE JOLLY ROGER, run by PEGLEG.  Welcome aboard!        º
-        º                                                                            º
-        º                    In case you missed it in the public announcement,       º
-        º                    please welcome RAZOR'S new COURIER HQ Suburbia!         º
-        º                                                                            º
-        º                    If you feel you can help us out in any way, contact     º
-        º                    Marauder on any RAZOR HQ and leave a detailed message.  º
-        º                                                                            º
-        ÓÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄ½
+        ╓────────────────────────────────────────────────────────────────────────────╖
+        ║                                                                            ║
+        ║  ··· Written By :  http://twitter.com/geoffreyhuntley                      ║
+        ║                                                                            ║
+        ╟────────────────────────────────────────────────────────────────────────────╢
+        ║                                                                            ║
+        ║  ··· Release Notes : Did you know that a NFT is just a hyperlink [1] to an ║
+        ║                    image thats usually hosted on Google Drive or another   ║
+        ║                    web2.0 webhost?                                         ║   
+        ║                                                                            ║
+        ║                    People are dropping millions on instructions on how to  ║
+        ║                    download images. That's why you can right click save-as ║
+        ║                    because they are standard images. The image is not      ║
+        ║                    stored in the blockchain contract.                      ║
+        ║                                                                            ║
+        ║                    As web2.0 webhosts are known to go offline (404 errors) ║
+        ║                    this handy torrent contains all of the NFT's so that    ║
+        ║                    future generations can study this generations tulip     ║
+        ║                    mania and collectively go...                            ║
+        ║                                                                            ║
+        ║                                                                            ║
+        ║                    "WTF? We destroyed our planet for THIS?!"               ║
+        ║                                                                            ║
+        ║                                           --- Geoffrey Huntley             ║
+        ║                                                                            ║
+        ║ [1] https://arweave.news/nft-404/                                          ║
+        ║                                                                            ║
+        ╟────────────────────────────────────────────────────────────────────────────╢
+        ║                                                                            ║
+        ║  ··· Group News :  RAZOR 1911 has experienced a few changes over the last  ║
+        ║                    weeks so, but rest assured, the rumours of our          ║
+        ║                    demise have been GREATLY exaggerated...                 ║
+        ║                                                                            ║
+        ║                    Please welcome back to RAZOR BLADE to the RAZOR 1911    ║
+        ║                    Leader board!                                           ║
+        ║                                                                            ║
+        ║                    Please welcome back to THE RENEGADE CHEMIST to the      ║
+        ║                    RAZOR 1911 member list!                                 ║
+        ║                                                                            ║
+        ║                    Please welcome DARK OVERLORD to the RAZOR 1911          ║
+        ║                    cracking team!                                          ║
+        ║                                                                            ║
+        ║                    Please welcome KEANU to the RAZOR 1911 team!            ║
+        ║                                                                            ║
+        ║                    Please also give welcome to RAZOR's newest additions    ║
+        ║                    to the kick-ass spread team:  The Calibre &             ║
+        ║                    Black Mantle                                            ║
+        ║                                                                            ║
+        ║                    Please welcome RAZOR'S newest affiliate:                ║
+        ║                    THE JOLLY ROGER, run by PEGLEG.  Welcome aboard!        ║
+        ║                                                                            ║
+        ║                    In case you missed it in the public announcement,       ║
+        ║                    please welcome RAZOR'S new COURIER HQ Suburbia!         ║
+        ║                                                                            ║
+        ║                    If you feel you can help us out in any way, contact     ║
+        ║                    Marauder on any RAZOR HQ and leave a detailed message.  ║
+        ║                                                                            ║
+        ╙────────────────────────────────────────────────────────────────────────────╜
        
-        ÖÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄ·
-        º  Mirage            World HQ     10 Nodes    ITS.PRI.VATE    Big Boss       º
-        º  Suburbia          Courier HQ    6 Nodes    ITS.PRI.VATE    The Chairman   º
-        º  State/Devolution  USHQ          6 Nodes    ITS.PRI.VATE    Marauder       º
-        º  Aquila            European HQ   3 Nodes    +31.PRI.VATE    The Brain      º
-        ÇÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄ¶
-        º  Exalted Death     Member Board  2 Nodes    314.PRI.VATE    DeaD GooN      º
-        º  The City          Member Board  4 Nodes    813.PRI.VATE    War Master     º
-        º  Violent Plygrnd.  Member Board  1 Node     +46.PRI.VATE    Laric          º
-        ÇÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄ¶
-        º  Central Park      Affiliate     3 Nodes    +61.PRI.VATE    Grim           º
-        º  Dream Theatre     Affiliate     4 Nodes    314.PRI.VATE    Attitude       º
-        º  Electric Requiem  Affiliate     2 Nodes    602.PRI.VATE    Lord Shred     º
-        º  Maximum Overdrive Affiliate     3 Nodes    512.PRI.VATE    Twin Turbo     º
-        º  Midpoint Void     Affiliate     2 Nodes    303.PRI.VATE    Holy Ward      º
-        º  Pirates Hideout   Affiliate     2 Nodes    +46.PRI.VATE    BlackSmith     º
-        º  Reggae Muffin     Affiliate     2 Nodes    +47.PRI.VATE    Illegal E?ror  º
-        º  The Castle        Affiliate     5 Nodes    604.PRI.VATE    The Wizard     º
-        º  The Depths        Affiliate     1 Node     214.PRI.VATE    Maelstrom      º
-        º  The Jolly Roger   Affiliate     2 Nodes    404.PRI.VATE    Pegleg         º
-        º  Bad Dreams        Affiliate     2 Nodes    305.PRI.VATE    Uncvtd Felon   º
-        ÇÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄ¶
-        º  The Pentagon      Outpost       3 Nodes    +31.PRI.VATE    Grimlock       º
-        ÓÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄ½
+        ╓────────────────────────────────────────────────────────────────────────────╖
+        ║  Mirage            World HQ     10 Nodes    ITS.PRI.VATE    Big Boss       ║
+        ║  Suburbia          Courier HQ    6 Nodes    ITS.PRI.VATE    The Chairman   ║
+        ║  State/Devolution  USHQ          6 Nodes    ITS.PRI.VATE    Marauder       ║
+        ║  Aquila            European HQ   3 Nodes    +31.PRI.VATE    The Brain      ║
+        ╟────────────────────────────────────────────────────────────────────────────╢
+        ║  Exalted Death     Member Board  2 Nodes    314.PRI.VATE    DeaD GooN      ║
+        ║  The City          Member Board  4 Nodes    813.PRI.VATE    War Master     ║
+        ║  Violent Plygrnd.  Member Board  1 Node     +46.PRI.VATE    Laric          ║
+        ╟────────────────────────────────────────────────────────────────────────────╢
+        ║  Central Park      Affiliate     3 Nodes    +61.PRI.VATE    Grim           ║
+        ║  Dream Theatre     Affiliate     4 Nodes    314.PRI.VATE    Attitude       ║
+        ║  Electric Requiem  Affiliate     2 Nodes    602.PRI.VATE    Lord Shred     ║
+        ║  Maximum Overdrive Affiliate     3 Nodes    512.PRI.VATE    Twin Turbo     ║
+        ║  Midpoint Void     Affiliate     2 Nodes    303.PRI.VATE    Holy Ward      ║
+        ║  Pirates Hideout   Affiliate     2 Nodes    +46.PRI.VATE    BlackSmith     ║
+        ║  Reggae Muffin     Affiliate     2 Nodes    +47.PRI.VATE    Illegal E?ror  ║
+        ║  The Castle        Affiliate     5 Nodes    604.PRI.VATE    The Wizard     ║
+        ║  The Depths        Affiliate     1 Node     214.PRI.VATE    Maelstrom      ║
+        ║  The Jolly Roger   Affiliate     2 Nodes    404.PRI.VATE    Pegleg         ║
+        ║  Bad Dreams        Affiliate     2 Nodes    305.PRI.VATE    Uncvtd Felon   ║
+        ╟────────────────────────────────────────────────────────────────────────────╢
+        ║  The Pentagon      Outpost       3 Nodes    +31.PRI.VATE    Grimlock       ║
+        ╙────────────────────────────────────────────────────────────────────────────╜
        
-        ÖÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄ·
-        º                          úú Razor 1911 Leaders úú                          º
-        º                             ~~~~~~~~~~~~~~~~~~                             º
-        º             Marauder - Razor Blade - Randall Flagg - The Brain             º
-        º                                                                            º
-        º                          úú Razor 1911 Members úú                          º
-        º                             ~~~~~~~~~~~~~~~~~~                             º
-        º                     Avalon, Big Boss, Cetis, Chairman,                     º
-        º                       Chessking, Chronic Halitosis,                        º
-        º               Dark Overlord, Dead Goon, Fallen Angel, Grim,                º
-        º                  James Bomb, Keanu, Laric, Odin, Phoenix,                  º
-        º                       Serpico, The Renegade Chemist,                       º
-        º                          War Master, Wind Walker                           º
-        º                                                                            º
-        º              úú Razor 1911 Coding/Training/Art Departments úú              º
-        º                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                 º
-        º                    Zebig, Mitch, Martial Artist, Laric                     º
-        º                       Night Slasher, Red Wizard, Jed                       º
-        º                                                                            º
-        º                      úú Razor 1911 DoX Specialists úú                      º
-        º                         ~~~~~~~~~~~~~~~~~~~~~~~~~~                         º
-        º                The Chairman, Lorus, Morton, and The Punisher               º
-        º                                                                            º
-        ÓÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄ½
-        ÖÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄ·
-        º                                                                            º
-        º                    úú Razor 1911 Courier Coordinator úú                    º
-        º                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                       º
-        º                                 The Brain                                  º
-        º                                                                            º
-        º                      úú Razor 1911 Senior Couriers úú                      º
-        º                         ~~~~~~~~~~~~~~~~~~~~~~~~~~                         º
-        º                           Faldo and The Dutchmen                           º
-        º                                                                            º
-        º                      úú Razor 1911 Elite Couriers úú                       º
-        º                          ~~~~~~~~~~~~~~~~~~~~~~~~~                         º
-        º             Cobretti, Cremator, Death Knight, Digital Justice,             º
-        º                Homer, King Lear, Minstrel, Moon, Obliviax,                 º
-        º                    Prophet, Rage, The Cardinal, Vivid                      º
-        º                                                                            º
-        º                      úú Razor 1911 Trial Couriers úú                       º
-        º                         ~~~~~~~~~~~~~~~~~~~~~~~~~                          º
-        º                   Corwin of Amber, Cyberpunk, Egg Head,                    º
-        º                         The Calibre, Black Mantle                          º
-        ÓÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄ½
-        ÖÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄ·
-        º   Beware of FAKE RAZOR MEMBERS/BOARDS/ETC!  If they are not in this NFO,   º
-        º                        THEN THEY ARE NOT IN RAZOR!                         º
-        ÓÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄ½
-        ÖÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄ·
-        º                                                                            º
-        º  Razor 1911 is always looking for loyal and interested people to keep the  º
-        º  blade sharp.  If you want to apply to be a courier, affiliate, or even a  º
-        º  member, please call any of the RAZOR 1911 HQ boards and leave a message   º
-        º  for Marauder.  Have someone forward your message if you cannot get on...  º
-        º                                                                            º
-        º  Interested in Razor-DoX?  Call +1-214-445-0790 and run the Razor-DoX app  º
-        º                                 generator.                                 º
-        º                                                                            º
-        º                          You may write to us at :                          º
-        º                                                                            º
-        º                             RAZOR 1911 PC USA                              º
-        º                     7154 NORTH UNIVERSITY DRIVE #21911                     º
-        º                             TAMARAC, FL 33321                              º
-        º                                    USA                                     º
-        º                                                                            º
-        ÓÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄ½
+        ╓────────────────────────────────────────────────────────────────────────────╖
+        ║                          ·· Razor 1911 Leaders ··                          ║
+        ║                             ~~~~~~~~~~~~~~~~~~                             ║
+        ║             Marauder - Razor Blade - Randall Flagg - The Brain             ║
+        ║                                                                            ║
+        ║                          ·· Razor 1911 Members ··                          ║
+        ║                             ~~~~~~~~~~~~~~~~~~                             ║
+        ║                     Avalon, Big Boss, Cetis, Chairman,                     ║
+        ║                       Chessking, Chronic Halitosis,                        ║
+        ║               Dark Overlord, Dead Goon, Fallen Angel, Grim,                ║
+        ║                  James Bomb, Keanu, Laric, Odin, Phoenix,                  ║
+        ║                       Serpico, The Renegade Chemist,                       ║
+        ║                          War Master, Wind Walker                           ║
+        ║                                                                            ║
+        ║              ·· Razor 1911 Coding/Training/Art Departments ··              ║
+        ║                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                 ║
+        ║                    Zebig, Mitch, Martial Artist, Laric                     ║
+        ║                       Night Slasher, Red Wizard, Jed                       ║
+        ║                                                                            ║
+        ║                      ·· Razor 1911 DoX Specialists ··                      ║
+        ║                         ~~~~~~~~~~~~~~~~~~~~~~~~~~                         ║
+        ║                The Chairman, Lorus, Morton, and The Punisher               ║
+        ║                                                                            ║
+        ╙────────────────────────────────────────────────────────────────────────────╜
+        ╓────────────────────────────────────────────────────────────────────────────╖
+        ║                                                                            ║
+        ║                    ·· Razor 1911 Courier Coordinator ··                    ║
+        ║                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                       ║
+        ║                                 The Brain                                  ║
+        ║                                                                            ║
+        ║                      ·· Razor 1911 Senior Couriers ··                      ║
+        ║                         ~~~~~~~~~~~~~~~~~~~~~~~~~~                         ║
+        ║                           Faldo and The Dutchmen                           ║
+        ║                                                                            ║
+        ║                      ·· Razor 1911 Elite Couriers ··                       ║
+        ║                          ~~~~~~~~~~~~~~~~~~~~~~~~~                         ║
+        ║             Cobretti, Cremator, Death Knight, Digital Justice,             ║
+        ║                Homer, King Lear, Minstrel, Moon, Obliviax,                 ║
+        ║                    Prophet, Rage, The Cardinal, Vivid                      ║
+        ║                                                                            ║
+        ║                      ·· Razor 1911 Trial Couriers ··                       ║
+        ║                         ~~~~~~~~~~~~~~~~~~~~~~~~~                          ║
+        ║                   Corwin of Amber, Cyberpunk, Egg Head,                    ║
+        ║                         The Calibre, Black Mantle                          ║
+        ╙────────────────────────────────────────────────────────────────────────────╜
+        ╓────────────────────────────────────────────────────────────────────────────╖
+        ║   Beware of FAKE RAZOR MEMBERS/BOARDS/ETC!  If they are not in this NFO,   ║
+        ║                        THEN THEY ARE NOT IN RAZOR!                         ║
+        ╙────────────────────────────────────────────────────────────────────────────╜
+        ╓────────────────────────────────────────────────────────────────────────────╖
+        ║                                                                            ║
+        ║  Razor 1911 is always looking for loyal and interested people to keep the  ║
+        ║  blade sharp.  If you want to apply to be a courier, affiliate, or even a  ║
+        ║  member, please call any of the RAZOR 1911 HQ boards and leave a message   ║
+        ║  for Marauder.  Have someone forward your message if you cannot get on...  ║
+        ║                                                                            ║
+        ║  Interested in Razor-DoX?  Call +1-214-445-0790 and run the Razor-DoX app  ║
+        ║                                 generator.                                 ║
+        ║                                                                            ║
+        ║                          You may write to us at :                          ║
+        ║                                                                            ║
+        ║                             RAZOR 1911 PC USA                              ║
+        ║                     7154 NORTH UNIVERSITY DRIVE #21911                     ║
+        ║                             TAMARAC, FL 33321                              ║
+        ║                                    USA                                     ║
+        ║                                                                            ║
+        ╙────────────────────────────────────────────────────────────────────────────╜
        
                           IF YOU LIKE THESE NFTS, PLEASE BUY IT.
                   THE ARTISTS PARTICIPATING IN FRAUD DESERVE SUPPORT! (c)
        
                                   -*- R A Z O R  1 9 1 1 -*-
        
-        ÖÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄ·
-        º                    VERSION CONTROL:  RAZOR.016 11/18/21                    º
-        ÓÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄÄ½
+        ╓────────────────────────────────────────────────────────────────────────────╖
+        ║                    VERSION CONTROL:  RAZOR.016 11/18/21                    ║
+        ╙────────────────────────────────────────────────────────────────────────────╜
 ```
 ## You wouldn't steal a JPEG (or would you...)


### PR DESCRIPTION
NFO files are usually encoded in CP 437, and the block characters are not interpreted correctly when parsed as UTF-8. That is the cause to the strange `ÜÛÖÄú` characters in the file. NFO used as reference: https://defacto2.net/f/b43766.