### PR TITLE
Fix size value in TiB and rounding

### DIFF
--- a/description.html
+++ b/description.html
@@ -326,15 +326,15 @@
                         <ol>
 
                             <li><span class="file-name">razor1911.nfo</span><span
-                                class="file-size">20&nbsp;KiB</span></li>
+                                class="file-size">17.3&nbsp;KiB</span></li>
 
                             <li><span class="file-name">preview.jpg</span><span
-                                    class="file-size">3.9&nbsp;MiB</span></li>
+                                    class="file-size">3.80&nbsp;MiB</span></li>
 
     
-                            <li class="alt"><span class="file-name">ethereum.tar</span><span class="file-size">14.9&nbsp;TiB</span></li>
+                            <li class="alt"><span class="file-name">ethereum.tar</span><span class="file-size">13.6&nbsp;TiB</span></li>
 
-                            <li><span class="file-name">solana.tar</span><span class="file-size">4.2&nbsp;TiB</span></li>
+                            <li><span class="file-name">solana.tar</span><span class="file-size">4.19&nbsp;TiB</span></li>
 
                         </ol>
                     </div>

--- a/description.html
+++ b/description.html
@@ -77,7 +77,7 @@
                             </div>
                             <div>
                                 <dt class="dt-sm">Size:</dt>
-                                <dd><label id="size">19.52&nbsp;TiB&nbsp;(1.952e+13 Bytes)</label></dd>
+                                <dd><label id="size">17.76&nbsp;TiB&nbsp;(1.953e+13 Bytes)</label></dd>
                             </div>
                             <label id="imdb"></label>
                             <br>


### PR DESCRIPTION
The exact size of the torrent is 19529900799009 bytes. Rounded to four significant digits, that's 19.53 TB (= 1.953e+13 B) or 17.76 TiB.