### PR TITLE
Description twitter link fix

### DIFF
--- a/description.html
+++ b/description.html
@@ -125,7 +125,7 @@
                     </div>
                     <div id="description_text" class="text-box"><label id="descr">
 
-                        <a href="https://twitter.com/GeoffreyHuntley/status/1461322836165885954/status/1461322836165885954"><img src="/images/razor1911nfo.png" width="90%"/></a>
+                        <a href="https://twitter.com/GeoffreyHuntley/status/1461322836165885954"><img src="/images/razor1911nfo.png" width="90%"/></a>
                         <!-- ÜÛÛÛÛ    ÜÜÛÛÛÛÛÛÛÛÛÜÜ      ÜÛÛÛÛ   ÜÛÛÛÛ
                         ÜÛÛÛÛÛÛ  ÜÛÛÛÛÛÛÛÛÛÛÛÛÛÛÛÜ  ÜÛÛÛÛÛÛ ÜÛÛÛÛÛÛ
                         ßßßÛÛÛÛ ÜÛÛÛÛßß     ßßÛÛÛÛÜ ßßßÛÛÛÛ ßßßÛÛÛÛ


### PR DESCRIPTION
Fixed broken description link from 
`https://twitter.com/GeoffreyHuntley/status/1461322836165885954/status/1461322836165885954`
to
`https://twitter.com/GeoffreyHuntley/status/1461322836165885954`

Cheers 😎

>All your NFT are belong to us